### PR TITLE
Fixed hook

### DIFF
--- a/genesis-skip-link/functions.php
+++ b/genesis-skip-link/functions.php
@@ -19,7 +19,7 @@
      * Add a link first thing after the body element that will skip to the inner element.
      */
     function theme_add_skip_link() {
-        echo '<a class="skip-link" href="#inner">Skip to content</a>';
+        echo '<a class="skip-link" href="#inner">' . __('Skip to content', 'theme-text-domain') . '</a>';
     }
     add_action( 'genesis_before', 'theme_add_skip_link', 1 );
 

--- a/genesis-skip-link/functions.php
+++ b/genesis-skip-link/functions.php
@@ -21,7 +21,7 @@
     function theme_add_skip_link() {
         echo '<a class="skip-link" href="#inner">Skip to content</a>';
     }
-    add_action( 'get_header', 'theme_add_skip_link', 1 );
+    add_action( 'genesis_before', 'theme_add_skip_link', 1 );
 
     /**
      * Tabindex fix for specific browsers to fix skip link.


### PR DESCRIPTION
Apparently using `get_header` places the link before the doctype declaration. Not sure how I didn't notice before (dev toolbar seems to not show this, the source does).

This should fix that.
