### PR TITLE
Improve .screen-reader-text

### DIFF
--- a/read-more-links/style.css
+++ b/read-more-links/style.css
@@ -4,6 +4,8 @@
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
 	height: 1px;
+	margin: -1px;
+	padding: 0;
 	overflow: hidden;
 	position: absolute !important;
 	width: 1px;

--- a/read-more-links/style.css
+++ b/read-more-links/style.css
@@ -5,8 +5,8 @@
 	clip-path: inset(50%);
 	height: 1px;
 	margin: -1px;
-	padding: 0;
 	overflow: hidden;
+	padding: 0;
 	position: absolute !important;
 	width: 1px;
 	word-wrap: normal !important;

--- a/read-more-links/style.css
+++ b/read-more-links/style.css
@@ -9,5 +9,5 @@
 	overflow: hidden;
 	position: absolute !important;
 	width: 1px;
-	white-space: nowrap;
+	word-wrap: normal !important;
 }

--- a/read-more-links/style.css
+++ b/read-more-links/style.css
@@ -1,8 +1,11 @@
 /* Text meant only for screen readers */
 .screen-reader-text {
+	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
 	height: 1px;
 	overflow: hidden;
 	position: absolute !important;
 	width: 1px;
+	white-space: nowrap;
 }


### PR DESCRIPTION
Bulletproofing this utility class:
* prevents border to appear, if any;
* progressively enhance the clip thing: `clip` [is deprecated](https://www.w3.org/TR/css-masking-1/#clip-property) and @ryuran [suggested the sorter possible version](https://twitter.com/ryuran78/status/778943389819604992) for `clip-path`;
* [J. Renée Beach warned about the single pixel width having side effects on text rendering and therefore on its vocalisation by screen readers](https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe#.vcd5xlpgg).

It's been widely tested [on this codepend](http://codepen.io/ffoodd/pen/gwKZyq?editors=1100#) and [proofread then translated on Hugo Giraudel's blog](http://hugogiraudel.com/2016/10/13/css-hide-and-seek/).

Please let me know if you find any issue related to this :)

And thanks a lot for those patterns, they're great <3